### PR TITLE
Fix doc dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,7 +25,6 @@ SpatialLeiden: spatially aware Leiden clustering.
 
    self
    installation
-   usage
    guides/index
    api
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ docs = [
     "scanpy",
     "squidpy",
     "spatialdata>=0.7.2", # due to https://github.com/scverse/spatialdata/issues/1065
-    "dask<2025",          # incompatibility of squidpy with dask >= 2025
     "myst-nb",
 ]
 dev = ["spatialleiden[docs]", "mudata~=0.3", "pre-commit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ docs = [
     "anndata>=0.10",
     "scanpy",
     "squidpy",
-    "dask<2025",         # incompatibility of squidpy with dask >= 2025
+    "spatialdata>=0.7.2", # due to https://github.com/scverse/spatialdata/issues/1065
+    "dask<2025",          # incompatibility of squidpy with dask >= 2025
     "myst-nb",
 ]
 dev = ["spatialleiden[docs]", "mudata~=0.3", "pre-commit"]


### PR DESCRIPTION
xarray-schema has outdated dependencies that do not work with newer setuptools version. 
updating spatialdata to avoid the issues